### PR TITLE
Add FastAPI template domain demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# TemplateSystem FastAPI Example
+
+This project serves dynamic pages based on the first path component as a domain name.
+When a domain is requested for the first time, the application generates a simple
+HTML template for that domain. Subsequent requests use the same template, giving
+all URLs under that domain a consistent look.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Visit `http://localhost:8000/cnn.com/news/example` to see a generated page for
+`cnn.com`. A file `cnn.com.html` will be placed under `app/templates/` and used
+for any further requests starting with `/cnn.com/`.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,50 @@
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+import os
+
+app = FastAPI()
+
+templates = Jinja2Templates(directory=os.path.join(os.path.dirname(__file__), 'templates'))
+
+# Cache for domain -> template name
+DOMAIN_TEMPLATES = {}
+
+TEMPLATE_DIR = templates.directory
+
+
+def create_template(template_name: str, domain: str) -> None:
+    """Create a simple template for a domain if it does not exist."""
+    path = os.path.join(TEMPLATE_DIR, template_name)
+    if os.path.exists(path):
+        return
+    content = (
+        '{% extends "base.html" %}\n'
+        '{% block content %}\n'
+        f'<p>Welcome to {{ domain }} replica.</p>\n'
+        '{% endblock %}\n'
+    )
+    with open(path, 'w') as f:
+        f.write(content)
+
+
+@app.get("/{full_path:path}", response_class=HTMLResponse)
+async def mirror(full_path: str, request: Request):
+    """Handle incoming paths and render domain specific templates."""
+    if not full_path:
+        raise HTTPException(status_code=404)
+
+    parts = full_path.split("/")
+    domain = parts[0]
+    subpath = "/".join(parts[1:])
+
+    template_name = DOMAIN_TEMPLATES.get(domain)
+    if not template_name:
+        template_name = f"{domain}.html"
+        create_template(template_name, domain)
+        DOMAIN_TEMPLATES[domain] = template_name
+
+    return templates.TemplateResponse(
+        template_name,
+        {"request": request, "domain": domain, "path": subpath},
+    )

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ domain }} - Mirror</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0 auto; max-width: 700px; }
+        header { padding: 1rem; background-color: #333; color: white; }
+    </style>
+</head>
+<body>
+    <header>{{ domain }}</header>
+    <main>
+        <p>Path: {{ path }}</p>
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+Jinja2


### PR DESCRIPTION
## Summary
- add a simple FastAPI app
- generate per-domain templates when first seen
- include base HTML template
- document how to run the server

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686434b8a498832aa607edbfedf26e45