### PR TITLE
Add unique color themes per domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 This project serves dynamic pages based on the first path component as a domain name.
 When a domain is requested for the first time, the application generates a simple
-HTML template for that domain. Subsequent requests use the same template, giving
-all URLs under that domain a consistent look.
+HTML template for that domain. Subsequent requests reuse the same template. Each
+domain gets a unique color scheme so mirrored pages are distinct while sharing a
+common layout.
 
 ## Installation
 
@@ -19,4 +20,5 @@ uvicorn app.main:app --reload
 
 Visit `http://localhost:8000/cnn.com/news/example` to see a generated page for
 `cnn.com`. A file `cnn.com.html` will be placed under `app/templates/` and used
-for any further requests starting with `/cnn.com/`.
+for any further requests starting with `/cnn.com/`. The header will use CNN's
+signature red color automatically.

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,7 +4,7 @@
     <title>{{ domain }} - Mirror</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 0 auto; max-width: 700px; }
-        header { padding: 1rem; background-color: #333; color: white; }
+        header { padding: 1rem; background-color: {{ color | default('#333') }}; color: white; }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- introduce domain-specific colors
- allow the base template to use the chosen color
- note the new behavior in the README

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6864365fab48832a87c9f9e92d3c9682